### PR TITLE
DHL Recipient Fix

### DIFF
--- a/src/Trackers/DHL.php
+++ b/src/Trackers/DHL.php
@@ -167,9 +167,9 @@ class DHL extends AbstractTracker
     protected function getRecipient(DOMXPath $xpath)
     {
         $node = $xpath->query("//div[contains(@class,'parcel-details')]/dl/dd");
-
-        if ($node && $node->length > 1) {
-            return $this->getNodeValue($node->item(1));
+    
+        if ($node && $node->length >= 1) {
+            return $this->getNodeValue($node->item($node->length - 1));
         }
 
         return null;


### PR DESCRIPTION
fixed the recipient extraction for dhl. parcel-details could provide only one node so it's better to accept one or more items and return the last