### PR TITLE
Fix to the issue #15 implemented.

### DIFF
--- a/src/Trackers/DHL.php
+++ b/src/Trackers/DHL.php
@@ -76,8 +76,8 @@ class DHL extends AbstractTracker
 
         foreach ($this->getEvents($xpath) as $event) {
             $track->addEvent(Event::fromArray([
-                'description' => strip_tags($event->status),
-                'status' => $status = $this->resolveStatus(strip_tags($event->status)),
+                'description' => isset($event->status) ? strip_tags($event->status) : '',
+                'status' => isset($event->status) ? $status = $this->resolveStatus(strip_tags($event->status)) : '',
                 'date' => Carbon::parse($event->datum),
                 'location' => isset($event->ort) ? $event->ort : '',
             ]));

--- a/src/Trackers/DHL.php
+++ b/src/Trackers/DHL.php
@@ -77,7 +77,7 @@ class DHL extends AbstractTracker
         foreach ($this->getEvents($xpath) as $event) {
             $track->addEvent(Event::fromArray([
                 'description' => isset($event->status) ? strip_tags($event->status) : '',
-                'status' => isset($event->status) ? $status = $this->resolveStatus(strip_tags($event->status)) : '',
+                'status' => $status = isset($event->status) ? $this->resolveStatus(strip_tags($event->status)) : '',
                 'date' => isset($event->datum) ? Carbon::parse($event->datum) : null,
                 'location' => isset($event->ort) ? $event->ort : '',
             ]));

--- a/src/Trackers/DHL.php
+++ b/src/Trackers/DHL.php
@@ -78,7 +78,7 @@ class DHL extends AbstractTracker
             $track->addEvent(Event::fromArray([
                 'description' => isset($event->status) ? strip_tags($event->status) : '',
                 'status' => isset($event->status) ? $status = $this->resolveStatus(strip_tags($event->status)) : '',
-                'date' => Carbon::parse($event->datum),
+                'date' => isset($event->datum) ? Carbon::parse($event->datum) : null,
                 'location' => isset($event->ort) ? $event->ort : '',
             ]));
 


### PR DESCRIPTION
To avoid calling missing properties on an object, checks fot the `$event`'s properties added in the `Sauladam\ShipmentTracker\Trackers\DHL#getTrack(...)` .