### PR TITLE
Return weight for FedEx shipments as additional detail.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -125,6 +125,10 @@ Tracks and Events both can hold additional details, accessible via e.g. `$track-
   - `$track->getAdditionalDetails('pieces')` gets the tracking numbers of the individual pieces that belong to this shipment 
   - `$event->getAdditionalDetails('pieces')` gets the tracking numbers of the individual pieces to which this event applies
 
+- **FedEx:**
+  - `$track->getAdditionalDetails('totalKgsWgt')` gets the weight of the shipment in kgs if it's returned
+  - `$track->getAdditionalDetails('totalLbsWgt')` gets the weight of the shipment in lbs if it's returned
+
 ### Data Providers
 By default, this package uses Guzzle as well as the PHP Http client (a.k.a. `file_get_contents()`) to fetch the data. You can pass your own provider if you need to, e.g. if you have the page contents chillin' somewhere in a cache. Just make sure that it implements `Sauladam\ShipmentTracker\DataProviders\DataProviderInterface`, which only requires a `get()` method.
 

--- a/src/Trackers/Fedex.php
+++ b/src/Trackers/Fedex.php
@@ -111,6 +111,14 @@ class Fedex extends AbstractTracker
             }
         }
 
+        if (isset($contents['totalKgsWgt'])) {
+            $track->addAdditionalDetails('totalKgsWgt', $contents['totalKgsWgt']);
+        }
+
+        if (isset($contents['totalLbsWgt'])) {
+            $track->addAdditionalDetails('totalLbsWgt', $contents['totalLbsWgt']);
+        }
+
         return $track->sortEvents();
     }
 


### PR DESCRIPTION
Adds some additional details that can be returned for FedEx shipments.

As an aside, this got me thinking that a lot of data is being tossed out so it might actually make sense to provide the full response back in some way, although that seems to drift away from the spirit of this abstraction as a normalized interface across services.