### PR TITLE
update description of Fedex tracking

### DIFF
--- a/src/Trackers/Fedex.php
+++ b/src/Trackers/Fedex.php
@@ -101,7 +101,7 @@ class Fedex extends AbstractTracker
         foreach ($contents['scanEventList'] as $scanEvent) {
             $track->addEvent(Event::fromArray([
                 'location'    => $scanEvent['scanLocation'],
-                'description' => $scanEvent['scanDetails'],
+                'description' => $scanEvent['status'],
                 'date'        => $this->getDate($scanEvent),
                 'status'      => $status = $this->resolveState($scanEvent)
             ]));


### PR DESCRIPTION
I am proposing to change Fedex tracking description, because your field 'scanDetails' is empty all the time